### PR TITLE
feat(utils): add joinURL utility with unit tests

### DIFF
--- a/src/utils/joinURL.ts
+++ b/src/utils/joinURL.ts
@@ -1,0 +1,19 @@
+export const joinURL = (baseURL: string | undefined, url: string): string => {
+	if (/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(url)) {
+		return url.split('?')[0]
+	}
+
+	if (!baseURL) return url.split('?')[0]
+
+	const urlWithoutSearch = url.split('?')[0]
+
+	const normalizedBaseURL = baseURL.endsWith('/')
+		? baseURL.slice(0, -1)
+		: baseURL
+
+	const normalizedURL = urlWithoutSearch.startsWith('/')
+		? urlWithoutSearch.slice(1)
+		: urlWithoutSearch
+
+	return `${normalizedBaseURL}/${normalizedURL}`
+}

--- a/tests/utils/joinURL.test.ts
+++ b/tests/utils/joinURL.test.ts
@@ -1,0 +1,58 @@
+import { joinURL } from 'src/utils/joinURL'
+
+describe('joinURL', () => {
+	test('Объединения URL', () => {
+		const baseURL = 'https://example.com/api/'
+		const url = '/v1/resource'
+
+		const result = joinURL(baseURL, url)
+		const result2 = joinURL(`${baseURL}`, url)
+
+		expect(result).toBe('https://example.com/api/v1/resource')
+		expect(result2).toBe('https://example.com/api/v1/resource')
+	})
+
+	test('Объединения без baseURL', () => {
+		const url = '/api/v1/resource'
+
+		const result = joinURL(undefined, url)
+
+		expect(result).toBe('/api/v1/resource')
+	})
+
+	test('Объединения с пустым baseURL', () => {
+		const baseURL = ''
+		const url = '/api/v1/resource'
+
+		const result = joinURL(baseURL, url)
+
+		expect(result).toBe('/api/v1/resource')
+	})
+
+	test('Объединения с некорректными URL', () => {
+		const baseURL = 'https://example.com/api'
+		const url = '/%%invalid-url'
+
+		const result = joinURL(baseURL, url)
+
+		expect(result).toBe('https://example.com/api/%%invalid-url')
+	})
+
+	test('Удалять параметры поиска из URL', () => {
+		const baseURL = 'https://example.com/api'
+		const url = 'v1/resource?existing=1&search=test'
+
+		const result = joinURL(baseURL, url)
+
+		expect(result).toBe('https://example.com/api/v1/resource')
+	})
+
+	test('Объединение с полным абсолютным url', () => {
+		const baseURL = 'https://example.com/api'
+		const url = 'https://another-site.com/v1/resource?query=test'
+
+		const result = joinURL(baseURL, url)
+
+		expect(result).toBe('https://another-site.com/v1/resource')
+	})
+})


### PR DESCRIPTION
This PR introduces a new utility function `joinURL` for handling URL concatenation and ensuring proper formatting. Additionally, it includes unit tests for the `joinURL` function to verify its behavior and edge cases.

Changes:
- Added `joinURL` utility function in the utils module.
- Created unit tests to validate the correctness of `joinURL` functionality.