### PR TITLE
feat(utils): add buildQueryParams utility with tests

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+export type EchoSearchParams = {
+	[key: string]:
+		| string
+		| number
+		| boolean
+		| null
+		| undefined
+		| Array<string | number | boolean | null | undefined>
+}

--- a/src/utils/buildQueryParams.ts
+++ b/src/utils/buildQueryParams.ts
@@ -1,0 +1,26 @@
+import { EchoSearchParams } from 'src/types'
+
+export const buildQueryParams = (params?: EchoSearchParams) => {
+	if (!params) return ''
+
+	const searchParams = new URLSearchParams()
+
+	for (const key in params) {
+		if (Object.prototype.hasOwnProperty.call(params, key)) {
+			const value = params[key]
+
+			if (Array.isArray(value)) {
+				value.forEach(item => {
+					if (item !== undefined && item !== null && item !== '') {
+						searchParams.append(key, item.toString())
+					}
+				})
+			} else if (value !== undefined && value !== null && value !== '') {
+				searchParams.set(key, value.toString())
+			}
+		}
+	}
+
+	const queryString = searchParams.toString().replace(/\+/g, '%20')
+	return queryString ? `?${queryString}` : ''
+}

--- a/tests/utils/buildQueryParams.test.ts
+++ b/tests/utils/buildQueryParams.test.ts
@@ -1,0 +1,50 @@
+import { buildQueryParams } from 'src/utils/buildQueryParams'
+
+describe('buildQueryParams', () => {
+	test('Конструировать параметры в string', () => {
+		const params = { search: 'test', test: 10 }
+
+		const result = buildQueryParams(params)
+
+		expect(result).toBe('?search=test&test=10')
+	})
+
+	test('Обрабатывать массивы в параметрах', () => {
+		const params = { tags: ['foo', 'bar'] }
+
+		const result = buildQueryParams(params)
+
+		expect(result).toBe('?tags=foo&tags=bar')
+	})
+
+	test('Игнорировать undefined и null значения', () => {
+		const params = {
+			search: 'test',
+			tag: undefined,
+			extra: null
+		}
+
+		const result = buildQueryParams(params)
+
+		expect(result).toBe('?search=test')
+	})
+
+	test('Возвращать пустую строку при отсутствии параметров', () => {
+		const result = buildQueryParams(undefined)
+
+		expect(result).toBe('')
+	})
+
+	test('Возвращать пустую строку при всех пустых значениях', () => {
+		const params = {
+			search: '',
+			tags: [],
+			value: null,
+			count: undefined
+		}
+
+		const result = buildQueryParams(params)
+
+		expect(result).toBe('')
+	})
+})


### PR DESCRIPTION
This PR introduces the `buildQueryParams` utility for constructing URL query strings from object parameters. The utility handles arrays, ignores empty values, and ensures proper encoding.

Changes:
- Added `buildQueryParams` utility function.
- Implemented unit tests to cover all branches, including edge cases with empty values.
- Added the `EchoSearchParams` type for better type safety.