### PR TITLE
feat(utils): add formattedBody utility with tests

### DIFF
--- a/src/utils/formattedBody.ts
+++ b/src/utils/formattedBody.ts
@@ -1,0 +1,6 @@
+export const formattedBody = (body: any): BodyInit | undefined => {
+	if (!body) return
+	return body instanceof FormData || typeof body === 'string'
+		? body
+		: JSON.stringify(body)
+}

--- a/tests/utils/formattedBody.test.ts
+++ b/tests/utils/formattedBody.test.ts
@@ -1,0 +1,42 @@
+import { formattedBody } from 'src/utils/formattedBody'
+
+describe('formattedBody', () => {
+	test('Обрабатывать FormData', () => {
+		const body = new FormData()
+		body.append('file', 'data')
+
+		const result = formattedBody(body)
+
+		expect(result).toBeInstanceOf(FormData)
+	})
+
+	test('Обрабатывать string', () => {
+		const body = 'test body'
+
+		const result = formattedBody(body)
+
+		expect(result).toBe('test body')
+	})
+
+	test('Обрабатывать number', () => {
+		const body = 123
+
+		const result = formattedBody(body)
+
+		expect(result).toBe('123')
+	})
+
+	test('Сериализовать объекты в JSON', () => {
+		const body = { key: 'value' }
+
+		const result = formattedBody(body)
+
+		expect(result).toBe('{"key":"value"}')
+	})
+
+	test('Возвращать undefined, если тело не задано', () => {
+		const result = formattedBody(undefined)
+
+		expect(result).toBeUndefined()
+	})
+})


### PR DESCRIPTION
This PR introduces the `formattedBody` utility for preparing request bodies in a proper format for HTTP requests. The utility handles both FormData and string types directly, while serializing other types into JSON.

Changes:
- Added `formattedBody` utility function to format request bodies.
- Added unit tests to ensure correct handling of various input types.