### PR TITLE
feat(core): add EchoClient with tests, error handling, and features

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -36,21 +36,16 @@ export class EchoClient {
 	}
 
 	private returnResponseData = async (req: EchoRequest, res: Response) => {
-		if (!req.responseType || !res.ok || req.responseType === 'original') {
+		if (!res.ok || !req.responseType) {
 			const contentType = res.headers?.get('Content-Type') || ''
 
-			if (!req.responseType || req.responseType === 'original') {
-				if (contentType.includes('application/json')) {
-					return res.json().catch(() => null)
-				}
-				if (contentType.startsWith('text/')) {
-					return res.text().catch(() => null)
-				}
-				if (contentType.includes('application/octet-stream')) {
-					return res.arrayBuffer().catch(() => null)
-				}
+			if (contentType.includes('application/json')) {
 				return res.json().catch(() => null)
 			}
+			if (contentType.includes('text/plain')) {
+				return res.text().catch(() => null)
+			}
+			return res.json().catch(() => null)
 		} else {
 			switch (req.responseType) {
 				case 'json':
@@ -67,6 +62,8 @@ export class EchoClient {
 					return res.formData()
 				case 'stream':
 					return res.body
+				case 'original':
+					return res
 				default:
 					throw new Error(`Unsupported responseType: ${req.responseType}`)
 			}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,144 @@
+import { EchoError, isEchoError } from './error'
+import {
+	EchoConfig,
+	EchoCreateConfig,
+	EchoRequest,
+	EchoRequestOptions,
+	EchoResponse
+} from './types'
+import { buildQueryParams } from './utils/buildQueryParams'
+import { deepMerge } from './utils/deepMerge'
+import { formattedBody } from './utils/formattedBody'
+import { joinURL } from './utils/joinURL'
+
+export type EchoClientInstance = Omit<EchoClient, 'createConfig'>
+
+export class EchoClient {
+	constructor(private readonly createConfig: EchoCreateConfig = {}) {}
+
+	protected configurator = (config: EchoConfig) => {
+		const { baseURL, url, params, body, ...configure } = {
+			...config,
+			headers: { ...config.headers }
+		}
+
+		const request: EchoRequest = {
+			...configure,
+			url: joinURL(baseURL, url) + buildQueryParams(params),
+			body: formattedBody(body)
+		}
+
+		if (body instanceof FormData) {
+			delete request.headers?.['Content-Type']
+		}
+
+		return { request, config }
+	}
+
+	private returnResponseData = async (req: EchoRequest, res: Response) => {
+		if (!req.responseType || !res.ok || req.responseType === 'original') {
+			const contentType = res.headers?.get('Content-Type') || ''
+
+			if (!req.responseType || req.responseType === 'original') {
+				if (contentType.includes('application/json')) {
+					return res.json().catch(() => null)
+				}
+				if (contentType.startsWith('text/')) {
+					return res.text().catch(() => null)
+				}
+				if (contentType.includes('application/octet-stream')) {
+					return res.arrayBuffer().catch(() => null)
+				}
+				return res.json().catch(() => null)
+			}
+		} else {
+			switch (req.responseType) {
+				case 'json':
+					return res.json()
+				case 'text':
+					return res.text()
+				case 'arrayBuffer':
+					return res.arrayBuffer()
+				case 'blob':
+					return res.blob()
+				case 'bytes':
+					return res.bytes()
+				case 'formData':
+					return res.formData()
+				case 'stream':
+					return res.body
+				default:
+					throw new Error(`Unsupported responseType: ${req.responseType}`)
+			}
+		}
+	}
+
+	protected fetch = async <T>(
+		config: EchoConfig,
+		request: EchoRequest
+	): Promise<EchoResponse<T>> => {
+		const fetchResponse = await fetch(request.url, request)
+		const { ok, status, statusText, headers } = fetchResponse
+		const data = await this.returnResponseData(request, fetchResponse)
+
+		const response: EchoResponse = {
+			data,
+			status,
+			statusText,
+			headers: Object.fromEntries(headers.entries()),
+			config,
+			request
+		}
+
+		if (!ok) {
+			throw new EchoError(
+				data?.message || statusText || 'Unexpected error',
+				config,
+				request,
+				response
+			)
+		}
+
+		return response
+	}
+
+	protected methods = (
+		request: <T>(config: EchoConfig) => Promise<EchoResponse<T>>
+	) => ({
+		get: <T>(url: string, options: EchoRequestOptions = {}) => {
+			return request<T>({ method: 'GET', url, ...options })
+		},
+		post: <T>(url: string, body?: any, options: EchoRequestOptions = {}) => {
+			return request<T>({ method: 'POST', url, body, ...options })
+		},
+		put: <T>(url: string, body?: any, options: EchoRequestOptions = {}) => {
+			return request<T>({ method: 'PUT', url, body, ...options })
+		},
+		patch: <T>(url: string, body?: any, options: EchoRequestOptions = {}) => {
+			return request<T>({ method: 'PATCH', url, body, ...options })
+		},
+		delete: <T>(url: string, options: EchoRequestOptions = {}) => {
+			return request<T>({ method: 'DELETE', url, ...options })
+		}
+	})
+
+	request = <T>(configure: EchoConfig): Promise<EchoResponse<T>> => {
+		const { request, config } = this.configurator(
+			deepMerge(this.createConfig, configure)
+		)
+
+		try {
+			return this.fetch<T>(config, request)
+		} catch (err: any) {
+			if (isEchoError(err)) throw err
+
+			const errorMessage = err.message || 'Unexpected error'
+			throw new EchoError(errorMessage, config, request)
+		}
+	}
+	get = this.methods(this.request).get
+	post = this.methods(this.request).post
+	put = this.methods(this.request).put
+	patch = this.methods(this.request).patch
+	delete = this.methods(this.request).delete
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -122,13 +122,13 @@ export class EchoClient {
 		}
 	})
 
-	request = <T>(configure: EchoConfig): Promise<EchoResponse<T>> => {
+	request = async <T>(configure: EchoConfig): Promise<EchoResponse<T>> => {
 		const { request, config } = this.configurator(
 			deepMerge(this.createConfig, configure)
 		)
 
 		try {
-			return this.fetch<T>(config, request)
+			return await this.fetch<T>(config, request)
 		} catch (err: any) {
 			if (isEchoError(err)) throw err
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,21 @@
+import { EchoConfig, EchoRequest, EchoResponse } from './types'
+
+export function isEchoError(error: any): error is EchoError {
+	return (
+		error instanceof EchoError ||
+		(typeof error === 'object' && error?.name === 'EchoError')
+	)
+}
+
+export class EchoError extends Error {
+	constructor(
+		public message: string,
+		public config: EchoConfig,
+		public request: EchoRequest,
+		public response?: EchoResponse
+	) {
+		super(message)
+		this.name = 'EchoError'
+		Object.setPrototypeOf(this, new.target.prototype)
+	}
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,36 @@
+export type ValueOf<T> = T[keyof T]
+
+// ----Enum
+
+export const EchoMethod = {
+	GET: 'GET',
+	POST: 'POST',
+	PUT: 'PUT',
+	PATCH: 'PATCH',
+	DELETE: 'DELETE'
+} as const
+export type EchoMethod = ValueOf<typeof EchoMethod>
+
+export const EchoResponseType = {
+	JSON: 'json',
+	TEXT: 'text',
+	ARRAY_BUFFER: 'arrayBuffer',
+	BLOB: 'blob',
+	BYTES: 'bytes',
+	FORM_DATA: 'formData',
+	STREAM: 'stream',
+	ORIGINAL: 'original'
+} as const
+export type EchoResponseType = ValueOf<typeof EchoResponseType>
+
+export const EchoInterceptors = {
+	REQUEST: 'request',
+	RESPONSE: 'response'
+} as const
+export type EchoInterceptors = ValueOf<typeof EchoInterceptors>
+
+// ----Const
+
 export type EchoSearchParams = {
 	[key: string]:
 		| string
@@ -6,4 +39,33 @@ export type EchoSearchParams = {
 		| null
 		| undefined
 		| Array<string | number | boolean | null | undefined>
+}
+
+// ----Config
+
+export type EchoConfig = Omit<RequestInit, 'method' | 'headers' | 'body'> & {
+	method: EchoMethod
+	url: string
+	baseURL?: string
+	params?: EchoSearchParams
+	headers?: Record<string, string>
+	responseType?: EchoResponseType
+	body?: any
+}
+export type EchoCreateConfig = Omit<EchoConfig, 'url' | 'method'>
+
+// ----Request
+
+export type EchoRequest = Omit<EchoConfig, 'baseURL' | 'params'>
+export type EchoRequestOptions = EchoCreateConfig
+
+// ----Response
+
+export type EchoResponse<T = any> = {
+	data: T
+	status: number
+	statusText: string
+	headers: Record<string, string>
+	config: EchoConfig
+	request: EchoRequest
 }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,0 +1,413 @@
+import fetchMock from 'jest-fetch-mock'
+import { EchoClient } from 'src/client'
+import { EchoError } from 'src/error'
+import { EchoResponse } from 'src/types'
+
+fetchMock.enableMocks()
+
+describe('EchoClient', () => {
+	let client: EchoClient
+
+	beforeEach(() => {
+		client = new EchoClient({
+			baseURL: 'https://api.example.com/api',
+			headers: { 'Content-Type': 'application/json' }
+		})
+	})
+
+	afterEach(() => {
+		fetchMock.resetMocks()
+	})
+
+	test('Инициализация клиента', () => {
+		expect(client).toBeDefined()
+	})
+
+	test('GET запрос', async () => {
+		fetchMock.mockResponseOnce(JSON.stringify({ message: 'Success' }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' }
+		})
+
+		const response: EchoResponse<{ message: string }> =
+			await client.get('/test')
+
+		expect(response.status).toBe(200)
+		expect(response.data).toEqual({ message: 'Success' })
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/test',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json'
+				})
+			})
+		)
+	})
+
+	test('GET запрос с query params', async () => {
+		fetchMock.mockResponseOnce(JSON.stringify({ result: 'OK' }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' }
+		})
+
+		const response = await client.get('/search', {
+			params: { q: 'test' }
+		})
+
+		expect(response.status).toBe(200)
+		expect(response.data).toEqual({ result: 'OK' })
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/search?q=test',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json'
+				})
+			})
+		)
+	})
+
+	test('GET запрос с query params -> спецсимволами', async () => {
+		fetchMock.mockResponseOnce(JSON.stringify({ message: 'Success' }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' }
+		})
+
+		const response = await client.get('/search', {
+			params: { q: 'hello world', sort: 'desc' }
+		})
+
+		expect(response.status).toBe(200)
+		expect(response.data).toEqual({ message: 'Success' })
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/search?q=hello%20world&sort=desc',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json'
+				})
+			})
+		)
+	})
+
+	test('GET запрос с query params -> массивами', async () => {
+		fetchMock.mockResponseOnce(JSON.stringify({ message: 'Success' }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' }
+		})
+
+		const response = await client.get('/search', {
+			params: { q: [2, 3], sort: 'desc' }
+		})
+
+		expect(response.status).toBe(200)
+		expect(response.data).toEqual({ message: 'Success' })
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/search?q=2&q=3&sort=desc',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json'
+				})
+			})
+		)
+	})
+
+	test('GET запрос с query params -> null и undefined', async () => {
+		fetchMock.mockResponseOnce(JSON.stringify({ message: 'Success' }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' }
+		})
+
+		const response = await client.get('/search', {
+			params: { test: null, value: undefined }
+		})
+
+		expect(response.status).toBe(200)
+		expect(response.data).toEqual({ message: 'Success' })
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/search',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json'
+				})
+			})
+		)
+	})
+
+	test('GET запрос без данных', async () => {
+		fetchMock.mockResponseOnce('', {
+			status: 204,
+			headers: { 'Content-Type': 'application/json' }
+		})
+
+		const response = await client.get('/no-content')
+
+		expect(response.status).toBe(204)
+		expect(response.data).toBeNull()
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/no-content',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json'
+				})
+			})
+		)
+	})
+
+	test('GET запрос c responseType -> text', async () => {
+		fetchMock.mockResponseOnce('Plain text response', {
+			status: 200,
+			headers: { 'Content-Type': 'text/plain' }
+		})
+
+		const response: EchoResponse<string> = await client.get('/text', {
+			responseType: 'text'
+		})
+
+		expect(response.status).toBe(200)
+		expect(response.data).toBe('Plain text response')
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/text',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json'
+				})
+			})
+		)
+	})
+
+	test('GET запрос responseType -> arrayBuffer', async () => {
+		const buffer = new Uint8Array([1, 2, 3, 4]).buffer
+
+		fetchMock.mockImplementationOnce(() =>
+			Promise.resolve(
+				new Response(buffer, {
+					status: 200,
+					headers: { 'Content-Type': 'application/octet-stream' }
+				})
+			)
+		)
+
+		const response = await client.get('/binary', {
+			responseType: 'arrayBuffer'
+		})
+
+		expect(response.status).toBe(200)
+		expect(response.data).toBeInstanceOf(ArrayBuffer)
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/binary',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json'
+				})
+			})
+		)
+	})
+
+	test('GET запрос responseType -> blob', async () => {
+		const blob = new Blob(['hello'], { type: 'text/plain' })
+
+		fetchMock.mockImplementationOnce(() =>
+			Promise.resolve(
+				new Response(blob, {
+					status: 200,
+					headers: { 'Content-Type': 'text/plain' }
+				})
+			)
+		)
+
+		const response = await client.get('/blob', { responseType: 'blob' })
+
+		expect(response.status).toBe(200)
+		expect(response.data?.constructor.name).toBe('Blob')
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/blob',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json'
+				})
+			})
+		)
+	})
+
+	test('POST запрос', async () => {
+		fetchMock.mockResponseOnce(JSON.stringify({ id: 1 }), {
+			status: 201,
+			headers: { 'Content-Type': 'application/json' }
+		})
+
+		const response: EchoResponse<{ id: number }> = await client.post(
+			'/create',
+			{ name: 'Test' }
+		)
+
+		expect(response.status).toBe(201)
+		expect(response.data).toEqual({ id: 1 })
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/create',
+			expect.objectContaining({
+				method: 'POST',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json'
+				}),
+				body: JSON.stringify({ name: 'Test' })
+			})
+		)
+	})
+
+	test('POST запрос c FormData', async () => {
+		const formData = new FormData()
+		formData.append('file', new Blob(['test content']), 'test.txt')
+
+		fetchMock.mockResponseOnce('Success', {
+			status: 200,
+			headers: { 'Content-Type': 'text/plain' }
+		})
+
+		const response: EchoResponse<string> = await client.post(
+			'/upload',
+			formData,
+			{ headers: { 'Content-Type': 'application/json' } }
+		)
+
+		expect(response.status).toBe(200)
+		expect(response.data).toBe('Success')
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/upload',
+			expect.objectContaining({
+				method: 'POST',
+				body: expect.any(FormData),
+				headers: expect.objectContaining({})
+			})
+		)
+	})
+
+	test('POST запрос с нестандартными заголовками', async () => {
+		fetchMock.mockResponseOnce(JSON.stringify({ success: true }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' }
+		})
+
+		const response = await client.post(
+			'/custom-headers',
+			{ test: 123 },
+			{
+				headers: { 'X-Custom-Header': 'test-value' }
+			}
+		)
+
+		expect(response.status).toBe(200)
+		expect(response.data).toEqual({ success: true })
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/custom-headers',
+			expect.objectContaining({
+				method: 'POST',
+				headers: expect.objectContaining({
+					'X-Custom-Header': 'test-value',
+					'Content-Type': 'application/json'
+				}),
+				body: expect.any(String)
+			})
+		)
+	})
+
+	test('PUT запрос', async () => {
+		fetchMock.mockResponseOnce(JSON.stringify({ updated: true }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' }
+		})
+
+		const response: EchoResponse<{ updated: boolean }> = await client.put(
+			'/update',
+			{ name: 'Test' }
+		)
+
+		expect(response.status).toBe(200)
+		expect(response.data).toEqual({ updated: true })
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/update',
+			expect.objectContaining({
+				method: 'PUT',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json'
+				}),
+				body: expect.any(String)
+			})
+		)
+	})
+
+	test('PATCH запрос', async () => {
+		fetchMock.mockResponseOnce(JSON.stringify({ patched: true }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' }
+		})
+
+		const response: EchoResponse<{ patched: boolean }> = await client.patch(
+			'/patch',
+			{ name: 'Test' }
+		)
+
+		expect(response.status).toBe(200)
+		expect(response.data).toEqual({ patched: true })
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/patch',
+			expect.objectContaining({
+				method: 'PATCH',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json'
+				}),
+				body: expect.any(String)
+			})
+		)
+	})
+
+	test('DELETE запрос', async () => {
+		fetchMock.mockResponseOnce('', { status: 204 })
+
+		const response = await client.delete('/delete')
+
+		expect(response.status).toBe(204)
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.com/api/delete',
+			expect.objectContaining({
+				method: 'DELETE',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json'
+				})
+			})
+		)
+	})
+
+	test('Обработка ответа с ошибкой', async () => {
+		fetchMock.mockResponseOnce(JSON.stringify({ error: 'Not Found' }), {
+			status: 404,
+			statusText: 'Not Found',
+			headers: { 'Content-Type': 'application/json' }
+		})
+
+		await expect(
+			client.get('/missing').catch(error => {
+				expect(error).toBeInstanceOf(EchoError)
+				expect(error.request.method).toBe('GET')
+				expect(error.response.status).toBe(404)
+				expect(error.response.data).toEqual({ error: 'Not Found' })
+
+				throw error
+			})
+		).rejects.toThrow(EchoError)
+	})
+
+	test('Обработка ошибок запроса', async () => {
+		fetchMock.mockRejectOnce(() => Promise.reject(new Error('Request Error')))
+
+		await expect(client.get('/error')).rejects.toThrow(EchoError)
+	})
+})

--- a/tests/error.test.ts
+++ b/tests/error.test.ts
@@ -1,0 +1,69 @@
+import { EchoError, isEchoError } from 'src/error'
+import { EchoConfig, EchoRequest, EchoResponse } from 'src/types'
+
+const mockConfig: EchoConfig = {
+	method: 'GET',
+	url: 'https://api.example.com/api'
+}
+const mockRequest: EchoRequest = {
+	method: 'GET',
+	url: 'https://api.example.com/api'
+}
+const mockResponse: EchoResponse = {
+	status: 200,
+	data: { success: true },
+	statusText: 'OK',
+	headers: { 'Content-Type': 'application/json' },
+	config: mockConfig,
+	request: mockRequest
+}
+
+describe('EchoError', () => {
+	it('должен создавать экземпляр EchoError с правильными свойствами', () => {
+		const error = new EchoError(
+			'Тестовая ошибка',
+			mockConfig,
+			mockRequest,
+			mockResponse
+		)
+
+		expect(error).toBeInstanceOf(EchoError)
+
+		expect(error.name).toBe('EchoError')
+		expect(error.message).toBe('Тестовая ошибка')
+		expect(error.config).toEqual(mockConfig)
+		expect(error.request).toEqual(mockRequest)
+		expect(error.response).toEqual(mockResponse)
+	})
+})
+
+describe('isEchoError', () => {
+	it('возвращать true для экземпляра EchoError', () => {
+		const error = new EchoError(
+			'Тестовая ошибка',
+			mockConfig,
+			mockRequest,
+			mockResponse
+		)
+
+		expect(isEchoError(error)).toBe(true)
+	})
+
+	it('возвращать true для объекта с именем "EchoError"', () => {
+		const error = { name: 'EchoError', message: 'Тестовая ошибка' }
+
+		expect(isEchoError(error)).toBe(true)
+	})
+
+	it('возвращать false для объекта с другим именем', () => {
+		const error = { name: 'SomeOtherError', message: 'Тестовая ошибка' }
+
+		expect(isEchoError(error)).toBe(false)
+	})
+
+	it('возвращать false для ошибки, не являющейся объектом', () => {
+		const error = 'Тестовая ошибка'
+
+		expect(isEchoError(error)).toBe(false)
+	})
+})


### PR DESCRIPTION
This PR introduces the `EchoClient` class for making HTTP requests with built-in error handling and flexible response types.

Changes:
- Added `EchoClient` with methods for `REQUEST`, `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`.
- Added `EchoError` for standardized error handling.
- Added unit tests for core functionality, including request processing and error scenarios.
