### PR TITLE
feat(build): restore build step in CI and add index file for library export

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,8 +18,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # - name: Build project
-      #   run: bun run build
+      - name: Build project
+        run: bun run build
 
       - name: Unit tests
         run: bun run test:unit

--- a/.npmignore
+++ b/.npmignore
@@ -11,7 +11,9 @@ bun.lockb
 tsconfig.json
 tsconfig.build.json
 dist/*.js
+dist/**/*.js
 dist/*.map
+dist/**/*.map
 !dist/index.cjs.js
 !dist/index.esm.js
 !dist/*.d.ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@yai-team/echo",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"main": "dist/index.cjs.js",
 	"module": "dist/index.esm.js",
 	"types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,11 @@
+import { EchoClient, type EchoClientInstance } from './client'
+import { Echo, type EchoInstance } from './echo'
+
+export * from './error'
+export * from './types'
+
+export { Echo, EchoClient }
+export type { EchoClientInstance, EchoInstance }
+
+const echo = new Echo()
+export default echo


### PR DESCRIPTION
This pull request restores the build step in the CI pipeline and adds an index file for library exports. Additionally, it updates the `.npmignore` to ensure proper exclusion of unnecessary files.

Changes
- Restored build step in CI pipeline.
- Added index file for library exports.
- Updated `.npmignore` to exclude unnecessary files.
